### PR TITLE
Ajout de contenus sans intérêt pour tester la génération de la barre de navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # PythonClassmates: I/O d'étudiants en programmation python
 
 Ce site propose d'offrir une plateforme de publication collaborative maintenue par les étudiants et mentors du *discord* des étudiants ***DA Python*** et ***Data Scientists*** d'*Openclassrooms*. L'objectif de ce dernier est de fournir des news, des didacticiels, des critiques de livres, des astuces en relation avec le langage de programmation python.
+
+__Lien vers le projet :__ [Python Classmates: I/O](https://www.pythonclassmates.org/)

--- a/content/articles/article.md
+++ b/content/articles/article.md
@@ -1,0 +1,7 @@
+Title: Ceci n'est pas un article
+Date: 2018-07-11 18:00
+Category: Articles
+Slug: article-test
+Author: Loïc Mangin
+
+Ce texte a juste pour fonction de tester la création de la catégorie 'article'.

--- a/content/da-python/python-path.md
+++ b/content/da-python/python-path.md
@@ -1,0 +1,9 @@
+Title: Ceci n'est pas une ressource pour le parcours
+Date: 2018-07-11 18:10
+Category: Parcours Python
+Slug: ressource-test
+Author: Loïc Mangin
+
+C'est pas avec ça que vous allez avancer vos projets...
+
+Je fais juste un essai pour la catégorie 'Parcours Python'.

--- a/content/infos/nouvelle-plateforme.md
+++ b/content/infos/nouvelle-plateforme.md
@@ -1,6 +1,6 @@
 Title: Une nouvelle plateforme de publication
 Date: 2018-07-02 9:00
-Category: Info
+Category: Infos
 Slug: une-nouvelle-plateforme
 Author: Thierry Chappuis
 

--- a/content/reviews/review.md
+++ b/content/reviews/review.md
@@ -1,0 +1,7 @@
+Title: Ceci n'est pas une critique
+Date: 2018-07-11 18:15
+Category: Reviews
+Slug: critique-test
+Author: Loïc Mangin
+
+Là y a pas de notes de lecture parce que j'ai pas fini le bouquin. :-p


### PR DESCRIPTION
**1)** J'ai ajouté 3 articles idiots pour que la barre de navigation fasse apparaître les tags ('Category') dans la barre de menu.
J'ai ensuite créé un dossier par catégorie et donc déplacé le post initial de Thierry. Le placement dans un dossier ou à la racine de `/content` semble ne rien changer au menu.

Curieusement, le menu ne s'est pas actualisé lorsque, pendant mes essais, j'ai modifié les intitulés de mes tags (du singulier au pluriel). :-/

**2)** J'ai aussi rajouté le lien vers le site dans le `README `(et je viens de me rendre compte qu'il était présent dans la description du repo... :-p ).