### PR TITLE
remove duplicates categories on navbar - change pelicanconf.py

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -15,6 +15,7 @@ EXTRA_PATH_METADATA = {
     'extra/favicon-32x32.png': {'path': 'favicon-32x32.png'}}
 FAVICON = 'favicon-32x32.png'
 MAIN_MENU = True
+DISPLAY_CATEGORIES_ON_MENU = False
 DISPLAY_PAGES_ON_MENU = False
 MENUITEMS = [
     ('News', '/category/news.html'),


### PR DESCRIPTION
Bonjour,
J'ai rajouté dans le fichier pelicanconf.py une ligne qui permet de ne pas afficher les catégories dans la barre de navgation. Dans la mesure où le MENUITEMS affiche déjà les catégories, ceci duplique les liens.
Bien à toi .
Aurélia.